### PR TITLE
Initial support for csv export for allocations

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -25,4 +25,15 @@ class AllocationsController < ApplicationController
 
     head 201
   end
+
+  def download
+    if current_user.role.name == "Admin"
+      send_data Allocation.to_csv, {
+                type: "text/csv; charset=iso-8859-1; header=present",
+                disposition: "attachment",
+                filename: "wdpa-tracker-allocations-#{Date.today}.csv" }
+    else
+      redirect_to root_path, notice: "Please request Admin rights to access this data"
+    end
+  end
 end

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -1,5 +1,6 @@
 class AllocationsController < ApplicationController
   before_action :authenticate_user!
+  before_action :authenticate_admin!, only: [:download]
 
   def index
   end
@@ -27,13 +28,17 @@ class AllocationsController < ApplicationController
   end
 
   def download
-    if current_user.role.name == "Admin"
-      send_data Allocation.to_csv, {
-                type: "text/csv; charset=iso-8859-1; header=present",
-                disposition: "attachment",
-                filename: "wdpa-tracker-allocations-#{Date.today}.csv" }
-    else
-      redirect_to root_path, notice: "Please request Admin rights to access this data"
+    send_data Allocation.to_csv, {
+              type: "text/csv; charset=iso-8859-1; header=present",
+              disposition: "attachment",
+              filename: "wdpa-tracker-allocations-#{Date.today}.csv" }
+  end
+
+  private
+
+  def authenticate_admin!
+    if current_user.role.name != "Admin"
+      redirect_to :root
     end
   end
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -2,4 +2,37 @@ class Allocation < ActiveRecord::Base
   belongs_to :country
   belongs_to :protected_area
   belongs_to :user
+
+  def self.to_csv
+    csv = ''
+    allocation_columns = Allocation.new.attributes.keys
+    allocation_columns.delete("created_at")
+    allocation_columns.delete("updated_at")
+    allocation_columns.delete("country_id")
+    allocation_columns << "Country"
+
+    allocation_columns.map! { |e|
+      e.gsub("_", " ").capitalize
+    }
+
+    csv << allocation_columns.join(',')
+    csv << "\n"
+
+    allocations = Allocation.all
+
+    allocations.to_a.each do |allocation|
+      allocation_attributes = allocation.attributes
+      allocation_attributes.delete("created_at")
+      allocation_attributes.delete("updated_at")
+      allocation_attributes[:country] = allocation.country.iso3
+      allocation_attributes.delete("country_id")
+
+      allocation_attributes = allocation_attributes.values.map{ |e| "\"#{e}\"" }
+      csv << allocation_attributes.join(',').to_s
+      csv << "\n"
+    end
+
+    csv
+
+  end
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -6,9 +6,7 @@ class Allocation < ActiveRecord::Base
   def self.to_csv
     csv = ''
     allocation_columns = Allocation.new.attributes.keys
-    allocation_columns.delete("created_at")
-    allocation_columns.delete("updated_at")
-    allocation_columns.delete("country_id")
+    allocation_columns.delete_if { |k, v| ["created_at", "updated_at", "country_id"].include? k }
     allocation_columns << "Country"
 
     allocation_columns.map! { |e|
@@ -22,10 +20,8 @@ class Allocation < ActiveRecord::Base
 
     allocations.to_a.each do |allocation|
       allocation_attributes = allocation.attributes
-      allocation_attributes.delete("created_at")
-      allocation_attributes.delete("updated_at")
       allocation_attributes[:country] = allocation.country.iso3
-      allocation_attributes.delete("country_id")
+      allocation_attributes.delete_if { |k, v| ["created_at", "updated_at", "country_id"].include? k }
 
       allocation_attributes = allocation_attributes.values.map{ |e| "\"#{e}\"" }
       csv << allocation_attributes.join(',').to_s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
 
   resources :countries, only: [:index]
   resources :users
-  resources :allocations
+  resources :allocations, only: [:index, :new, :create]
+
+  get '/allocations/download' => 'allocations#download'
 
   get '/search' => 'search#index'
   get '/:wdpa_id' => 'search#show', as: "protected_area"


### PR DESCRIPTION
I have added support for CSV download of allocations. This could use some improvement, such as using the user email address instead of id. Please let me know what changes you would like.